### PR TITLE
mlm training & stage2 training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,9 @@ run/logs
 
 # pdb
 *.pdb
+
+byprot-checkpoints/
+data-bin/
+generation-results/
+temp.ipynb
+run/

--- a/configs/experiment/lm/dplm_150m_stage2.yaml
+++ b/configs/experiment/lm/dplm_150m_stage2.yaml
@@ -6,7 +6,7 @@
 defaults:
   - /datamodule: uniref50
   - /callbacks: lm
-  - /trainer: ddp_bf16
+  - /trainer: ddp_fp16
 
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
@@ -35,6 +35,8 @@ model:
     arch_type: esm
     name: facebook/esm2_t30_150M_UR50D
     dropout: 0.1
+    pretrain: true
+    pretrained_model_name_or_path: facebook/esm2_t30_150M_UR50D
 
 task:
   _target_: lm/dplm
@@ -79,7 +81,7 @@ trainer:
   num_sanity_val_steps: 0
   reload_dataloaders_every_n_epochs: 1
   use_distributed_sampler: false
-  max_steps: 500_000
+  max_steps: 100_000
   accumulate_grad_batches: 1
   check_val_every_n_epoch: null
   val_check_interval: 1000

--- a/configs/experiment/lm/dplm_3b_stage2.yaml
+++ b/configs/experiment/lm/dplm_3b_stage2.yaml
@@ -12,8 +12,8 @@ defaults:
 # this allows you to overwrite only specified parameters
 
 # name of the run determines folder name in logs
-project: "DPLM_150m"
-name: "dplm_150m"
+project: "DPLM_3b"
+name: "dplm_3b"
 
 datamodule:
   max_tokens: 6000
@@ -33,8 +33,10 @@ model:
     modules_to_save: lm_head,esm.embeddings
   net:
     arch_type: esm
-    name: facebook/esm2_t30_150M_UR50D
+    name: facebook/esm2_t36_3B_UR50D
     dropout: 0.1
+    pretrain: true
+    pretrained_model_name_or_path: facebook/esm2_t36_3B_UR50D
 
 task:
   _target_: lm/dplm
@@ -79,7 +81,7 @@ trainer:
   num_sanity_val_steps: 0
   reload_dataloaders_every_n_epochs: 1
   use_distributed_sampler: false
-  max_steps: 500_000
+  max_steps: 100_000
   accumulate_grad_batches: 1
   check_val_every_n_epoch: null
   val_check_interval: 1000

--- a/configs/experiment/lm/dplm_650m_stage2.yaml
+++ b/configs/experiment/lm/dplm_650m_stage2.yaml
@@ -12,8 +12,8 @@ defaults:
 # this allows you to overwrite only specified parameters
 
 # name of the run determines folder name in logs
-project: "DPLM_150m"
-name: "dplm_150m"
+project: "DPLM_650m"
+name: "dplm_650m"
 
 datamodule:
   max_tokens: 6000
@@ -33,8 +33,10 @@ model:
     modules_to_save: lm_head,esm.embeddings
   net:
     arch_type: esm
-    name: facebook/esm2_t30_150M_UR50D
+    name: facebook/esm2_t33_650M_UR50D
     dropout: 0.1
+    pretrain: true
+    pretrained_model_name_or_path: facebook/esm2_t33_650M_UR50D
 
 task:
   _target_: lm/dplm
@@ -79,7 +81,7 @@ trainer:
   num_sanity_val_steps: 0
   reload_dataloaders_every_n_epochs: 1
   use_distributed_sampler: false
-  max_steps: 500_000
+  max_steps: 100_000
   accumulate_grad_batches: 1
   check_val_every_n_epoch: null
   val_check_interval: 1000

--- a/configs/experiment/lm/mlm_150m.yaml
+++ b/configs/experiment/lm/mlm_150m.yaml
@@ -12,8 +12,8 @@ defaults:
 # this allows you to overwrite only specified parameters
 
 # name of the run determines folder name in logs
-project: "DPLM_150m"
-name: "dplm_150m"
+project: "MLM_150m"
+name: "mlm_150m"
 
 datamodule:
   max_tokens: 6000
@@ -21,30 +21,21 @@ datamodule:
   mini_run: false
 
 model:
-  _target_: dplm
-  num_diffusion_timesteps: 500
-  gradient_ckpt: false
-  rdm_couple: false
-  lora:
-    lora: false
-    lora_rank: 16
-    lora_dropout: 0.1
-    lora_target_module: (esm.encoder.layer.[0-9]*.attention.(self.query|self.key|self.value|output.dense).*|esm.encoder.layer.[0-9]*.(intermediate|output).dense.*)
-    modules_to_save: lm_head,esm.embeddings
+  _target_: mlm_esm
   net:
     arch_type: esm
     name: facebook/esm2_t30_150M_UR50D
-    dropout: 0.1
+    dropout: 0.0
+  lora:
+    lora: false
 
 task:
-  _target_: lm/dplm
+  _target_: lm/mlm
   learning:
     noise: random_mask # enable cmlm training with uniform random masking
-    watch_t1_t2_loss: false
-    cal_constant_loss: false
-    weight: linear
+    mlm_prob: 0.15
   criterion:
-    _target_: byprot.modules.cross_entropy.RDMCrossEntropyLoss
+    _target_: byprot.modules.cross_entropy.Coord2SeqCrossEntropyLoss
     label_smoothing: 0.0
     ignore_index: 1
   optimizer:
@@ -60,13 +51,13 @@ task:
     warmup_steps: 2000
     total_steps: ${trainer.max_steps}
     lr: ${train.lr}
-    lr_end: 1e-5
+    lr_end: 4e-5
     warmup_init_lr: 1e-07
     power: 1
 
 train:
   seed: 42
-  lr: 0.00004
+  lr: 4e-4
   monitor: "val/loss"
   mode: "min"
   patience: 1000
@@ -76,7 +67,7 @@ trainer:
   max_epochs: 10000
   gradient_clip_val: 0.0
   # val_check_interval: 10
-  num_sanity_val_steps: 0
+  num_sanity_val_steps: 1
   reload_dataloaders_every_n_epochs: 1
   use_distributed_sampler: false
   max_steps: 500_000

--- a/src/byprot/tasks/lm/mlm.py
+++ b/src/byprot/tasks/lm/mlm.py
@@ -1,0 +1,248 @@
+import copy
+import os
+from typing import Any, Callable, List, Union
+
+import numpy as np
+import torch
+from byprot import utils
+from byprot.modules import metrics
+from byprot.tasks import TaskLitModule, register_task
+from byprot.utils.config import compose_config as Cfg, merge_config
+from lightning.pytorch.utilities import grad_norm
+
+from omegaconf import DictConfig
+from torch import nn
+from torch.nn import functional as F
+from torchmetrics import CatMetric, MaxMetric, MeanMetric, MinMetric, SumMetric
+from byprot.models.lm.model_utils import get_net
+
+log = utils.get_logger(__name__)
+
+def new_arange(x, *size):
+    """
+    Return a Tensor of `size` filled with a range function on the device of x.
+    If size is empty, using the size of the variable x.
+    """
+    if len(size) == 0:
+        size = x.size()
+    return torch.arange(size[-1], device=x.device).expand(*size).contiguous()
+
+
+@register_task('lm/mlm')
+class MLMTrainingTask(TaskLitModule):
+    _DEFAULT_CFG: DictConfig = Cfg(
+        learning=Cfg(
+            noise='random_mask',  # ['full_mask', 'random_mask']
+            num_unroll=0,
+            mlm_prob=0.15
+        ),
+        generator=Cfg(
+            max_iter=1,
+            temperature=0,
+        )
+    )
+    def __init__(
+        self,
+        model: Union[nn.Module, DictConfig],
+        criterion: Union[nn.Module, DictConfig],
+        optimizer: DictConfig,
+        lr_scheduler: DictConfig = None,
+        *,
+        learning=_DEFAULT_CFG.learning,
+        generator=_DEFAULT_CFG.generator
+    ):
+        super().__init__(model, criterion, optimizer, lr_scheduler)
+
+        # this line allows to access init params with 'self.hparams' attribute
+        # it also ensures init params will be stored in ckpt
+        self.save_hyperparameters(logger=True)
+    
+        self.build_model() 
+        self.tokenizer = self.model.tokenizer
+
+    def setup(self, stage=None) -> None:
+        super().setup(stage)
+
+        self.build_criterion()
+        self.build_torchmetric()
+
+        if self.stage == 'fit':
+            log.info(f'\n{self.model}')
+        elif self.stage == 'test':
+            self.test_step_outputs = []
+
+    def on_before_optimizer_step(self, optimizer):
+        if self.global_rank == 0:
+            grad_norm_dict = grad_norm(self.trainer.strategy.model, norm_type=2)
+            self.log_dict(grad_norm_dict)
+
+    def build_model(self):
+        wxy=1
+        self.model = get_net(cfg=self.hparams.model)
+
+    def build_criterion(self):
+        self.criterion = utils.instantiate_from_config(cfg=self.hparams.criterion) 
+        self.criterion.ignore_index = self.tokenizer.pad_token_id
+
+    def build_torchmetric(self):
+        self.eval_loss = MeanMetric()
+        self.eval_nll_loss = MeanMetric()
+
+        self.val_ppl_best = MinMetric()
+        
+        self.acc = MeanMetric()
+        self.acc_best = MaxMetric()
+    
+    @torch.no_grad()
+    def inject_noise(self, tokens):
+        padding_idx = self.tokenizer.pad_token_id
+        mask_idx = self.tokenizer.mask_token_id
+
+        def _mlm_mask(inputs):
+            prev_tokens = inputs.clone()
+            labels = inputs.clone()
+            # We sample a few tokens in each sequence for MLM training (with probability `self.mlm_probability`)
+            probability_matrix = torch.full(labels.shape, self.hparams.learning.mlm_prob).to(inputs.device)
+            special_tokens_mask = (
+                prev_tokens.eq(padding_idx)  # & mask
+                & prev_tokens.eq(self.tokenizer.cls_token_id)
+                & prev_tokens.eq(self.tokenizer.eos_token_id)
+            )
+
+            probability_matrix.masked_fill_(special_tokens_mask, value=0.0)
+            masked_indices = torch.bernoulli(probability_matrix).bool()
+
+            # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
+            indices_replaced = torch.bernoulli(torch.full_like(probability_matrix, 0.8)).bool() & masked_indices
+            prev_tokens[indices_replaced] = mask_idx
+
+            # 10% of the time, we replace masked input tokens with random word
+            indices_random = torch.bernoulli(torch.full_like(probability_matrix, 0.5)).bool() & masked_indices & ~indices_replaced
+            random_words = torch.randint(len(self.tokenizer), labels.shape).type_as(prev_tokens)
+            prev_tokens[indices_random] = random_words[indices_random]
+            
+            return prev_tokens, masked_indices
+
+        prev_tokens, prev_tokens_mask = _mlm_mask(tokens)
+
+        return prev_tokens, prev_tokens_mask
+    
+    def step(self, batch):
+        """
+        batch is a Dict containing:
+            - corrds: FloatTensor [bsz, len, n_atoms, 3], coordinates of proteins
+            - corrd_mask: BooltTensor [bsz, len], where valid coordinates
+                are set True, otherwise False
+            - lengths: int [bsz, len], protein sequence lengths
+            - tokens: LongTensor [bsz, len], sequence of amino acids     
+        """
+        tokens = batch['input_ids']
+
+        noised_tokens, noise_mask = self.inject_noise(
+            tokens
+        )
+
+        results = self.model(input_ids=noised_tokens)
+        logits = results['logits']
+        loss, logging_output = self.criterion(logits, tokens, label_mask=noise_mask)
+
+        if torch.isnan(loss):
+            print("Loss NAN on step ", self.global_step)
+            loss = loss * 0
+            logging_output['nll_loss'] = logging_output['nll_loss'] * 0
+            logging_output['fullseq_loss'] = logging_output['fullseq_loss'] * 0
+            logging_output['fullseq_nll_loss'] = logging_output['fullseq_nll_loss'] * 0
+            logging_output['ppl'] = logging_output['ppl'] * 0
+
+        return loss, logging_output
+
+    def training_step(self, batch: Any, batch_idx: int):
+        loss, logging_output = self.step(batch)
+
+        # log train metrics
+        self.log('global_step', self.global_step, on_step=True, on_epoch=False, prog_bar=True)
+        self.log('lr', self.lrate, on_step=True, on_epoch=False, prog_bar=True)
+
+        for log_key in logging_output:
+            log_value = logging_output[log_key]
+            self.log(f"train/{log_key}", log_value, on_step=True, on_epoch=False, prog_bar=True)
+        
+        return {"loss": loss}
+
+    # -------# Evaluating #-------- #
+    def on_test_epoch_start(self) -> None:
+        self.hparams.noise = 'full_mask'
+
+    def validation_step(self, batch: Any, batch_idx: int):
+        loss, logging_output = self.step(batch)
+        
+        # log other metrics
+        sample_size = logging_output['sample_size']
+        self.eval_loss.update(loss, weight=sample_size)
+        self.eval_nll_loss.update(logging_output['nll_loss'], weight=sample_size)
+
+        if self.stage == 'fit':
+            self.predict_step(batch, batch_idx)
+        return {"loss": loss}
+
+    def on_validation_epoch_end(self):
+        log_key = 'test' if self.stage == 'test' else 'val'
+
+        # compute metrics averaged over the whole dataset
+        eval_loss = self.eval_loss.compute()
+        self.eval_loss.reset()
+        eval_nll_loss = self.eval_nll_loss.compute()
+        self.eval_nll_loss.reset()
+        eval_ppl = torch.exp(eval_nll_loss)
+
+        self.log(f"{log_key}/loss", eval_loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(f"{log_key}/nll_loss", eval_nll_loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(f"{log_key}/ppl", eval_ppl, on_step=False, on_epoch=True, prog_bar=True)
+
+        if self.stage == 'fit':
+            self.val_ppl_best.update(eval_ppl)
+            self.log("val/ppl_best", self.val_ppl_best.compute(), on_epoch=True, prog_bar=True)
+
+            self.on_predict_epoch_end()
+
+        super().on_validation_epoch_end()
+        
+    # -------# Inference/Prediction #-------- #
+    def forward(self, batch, return_ids=False):
+        tokens = batch.pop('input_ids')
+
+        noised_tokens, noise_mask = self.inject_noise(
+            tokens,
+        )
+        batch['input_ids'] = noised_tokens
+
+        output_tokens, output_scores = self.model.generate(
+            batch=batch,
+            max_iter=self.hparams.generator.max_iter,
+            temperature=self.hparams.generator.temperature,
+            sampling_strategy='argmax',
+            partial_masks=~noise_mask,
+        )
+        if not return_ids:
+            return self.alphabet.decode(output_tokens)
+        return output_tokens, noise_mask
+
+    def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0, log_metrics=True) -> Any:
+        tokens = batch['input_ids'].clone()
+        pred_tokens, noise_mask = self.forward(batch, return_ids=True)
+
+        if log_metrics:
+            # # global accuracy
+            recovery_acc = metrics.accuracy(pred_tokens, tokens, mask=noise_mask)
+            self.acc.update(recovery_acc, weight=noise_mask.sum())
+
+    def on_predict_epoch_end(self) -> None:
+        log_key = 'test' if self.stage == 'test' else 'val'
+
+        acc = self.acc.compute() * 100
+        self.acc.reset()
+        self.log(f"{log_key}/acc", acc, on_step=False, on_epoch=True, prog_bar=True)
+
+        if self.stage == 'fit':
+            self.acc_best.update(acc)
+            self.log(f"{log_key}/acc_best", self.acc_best.compute(), on_epoch=True, prog_bar=True)


### PR DESCRIPTION
1. add mlm training task and config
2. add stage2 training code to the models/lm/model_utils.py
3. add stage2 training config as "dplm_{model_size}_stage2.yaml"
4. modify the DiffusionProteinLanguageModel.from_pretrained() method, where users can specify the net override config. For example, you load a DPLM model and want to use it for the representation learning, and you want to specify the dropout rate to 0.2, then you can use the following code to load: DiffusionProteinLanguageModel.from_pretrained('airkingbd/dplm_650m', net_override={'hidden_dropout_prob': 0.2})
