### PR TITLE
Temporarily avoid rich >=14.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ nbstripout      # remove output from jupyter notebooks
 
 # --------- others --------- #
 python-dotenv   # loading env variables from .env file
-rich            # beautiful text formatting in terminal
+rich==14.0.0    # beautiful text formatting in terminal
 pytest          # tests
 sh              # for running bash commands in some tests
 pudb            # debugger


### PR DESCRIPTION
Starting from rich 14.1.0, calling console.clear_live() results in `IndexError: pop from empty list`.
PR https://github.com/Textualize/rich/pull/3811 with the fix has not been merged since July.
Until the fix is merged, avoiding rich 14.1.0 and higher solves the issue.